### PR TITLE
Read auth0 roles from `app_metadata`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,13 @@
 [flake8]
-max-line-length = 88
+max-line-length = 120
 exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules,venv
 
 [pycodestyle]
-max-line-length = 88
+max-line-length = 120
 exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules,venv
 
 [isort]
-line_length = 88
+line_length = 120
 known_first_party = tahoe_auth0,config
 multi_line_output = 3
 default_section = THIRDPARTY

--- a/tahoe_auth0/backend.py
+++ b/tahoe_auth0/backend.py
@@ -9,6 +9,12 @@ from social_core.backends.oauth import BaseOAuth2
 from .api_client import Auth0ApiClient
 from .helpers import get_auth0_domain
 
+from .permissions import (
+    get_role_with_default,
+    is_organization_admin,
+    is_organization_staff,
+)
+
 
 class TahoeAuth0OAuth2(BaseOAuth2):
     """A python Social Auth OAuth authentication Backend hooked with Auth0"""
@@ -91,22 +97,32 @@ class TahoeAuth0OAuth2(BaseOAuth2):
         payload = self._get_payload(response)
         return payload["sub"]
 
-    def get_user_details(self, response):
+    def _build_user_details(self, jwt_payload, auth0_user):
         """
-        Fetches the user details from response's JWT.
+        Build user details from jwt_payload and auth0 user info from the API.
         """
-        payload = self._get_payload(response)
-        user_details = self.client.get_user(payload["email"])
+        app_metadata = auth0_user.get('app_metadata', {})
+        metadata_role = get_role_with_default(app_metadata)
 
-        nickname = user_details.get("nickname", payload.get("sub"))
+        nickname = auth0_user.get("nickname", jwt_payload.get("sub"))
         fullname, first_name, last_name = self.get_user_names(
-            fullname=user_details.get("name")
+            fullname=auth0_user.get("name")
         )
 
         return {
-            "username": user_details.get("username", nickname),
-            "email": user_details.get("email"),
+            "username": auth0_user.get("username", nickname),
+            "email": auth0_user.get("email"),
             "fullname": fullname,
             "first_name": first_name,
             "last_name": last_name,
+            "auth0_is_organization_admin": is_organization_admin(metadata_role),
+            "auth0_is_organization_staff": is_organization_staff(metadata_role),
         }
+
+    def get_user_details(self, response):
+        """
+        Fetches the user details from response's JWT and build the social_core JSON object.
+        """
+        jwt_payload = self._get_payload(response)
+        auth0_user = self.client.get_user(jwt_payload["email"])
+        return self._build_user_details(jwt_payload=jwt_payload, auth0_user=auth0_user)

--- a/tahoe_auth0/backend.py
+++ b/tahoe_auth0/backend.py
@@ -6,7 +6,8 @@ from urllib import request
 from jose import jwt
 from social_core.backends.oauth import BaseOAuth2
 
-from tahoe_auth0.api_client import Auth0ApiClient
+from .api_client import Auth0ApiClient
+from .helpers import get_auth0_domain
 
 
 class TahoeAuth0OAuth2(BaseOAuth2):
@@ -43,10 +44,10 @@ class TahoeAuth0OAuth2(BaseOAuth2):
         """
         id_token = response.get("id_token")
 
-        issuer = "https://{}/".format(self.client.domain)
+        issuer = "https://{}/".format(get_auth0_domain())
         audience = self.setting("KEY")  # CLIENT_ID
         jwks = request.urlopen(  # nosec
-            "https://{}/.well-known/jwks.json".format(self.client.domain)
+            "https://{}/.well-known/jwks.json".format(get_auth0_domain())
         )
 
         return jwt.decode(
@@ -72,13 +73,13 @@ class TahoeAuth0OAuth2(BaseOAuth2):
         return params
 
     def authorization_url(self):
-        return "https://{}/authorize".format(self.client.domain)
+        return "https://{}/authorize".format(get_auth0_domain())
 
     def access_token_url(self):
-        return "https://{}/oauth/token".format(self.client.domain)
+        return "https://{}/oauth/token".format(get_auth0_domain())
 
     def revoke_token_url(self, token, uid):
-        return "https://{}/logout".format(self.client.domain)
+        return "https://{}/logout".format(get_auth0_domain())
 
     def get_user_id(self, details, response):
         """

--- a/tahoe_auth0/permissions.py
+++ b/tahoe_auth0/permissions.py
@@ -1,0 +1,29 @@
+"""
+Permissions constants and utils for the tahoe-auth0 backend.
+"""
+
+
+AUTH0_ORG_ADMIN_ROLE = 'Admin'
+AUTH0_STUDIO_ROLE = 'Staff'
+AUTH0_DEFAULT_ROLE = 'Learner'
+
+
+def is_organization_admin(role):
+    """
+    Checks if organization admin, which grants admin rights and API access.
+    """
+    return role == AUTH0_ORG_ADMIN_ROLE
+
+
+def is_organization_staff(role):
+    """
+    Check if the role has Staff access which grants access to Open edX Studio.
+    """
+    return role == AUTH0_STUDIO_ROLE or is_organization_admin(role)
+
+
+def get_role_with_default(app_metadata):
+    """
+    Helper to get role from `app_metadata` and default to Learner.
+    """
+    return app_metadata.get('role', AUTH0_DEFAULT_ROLE)

--- a/tahoe_auth0/tests/test_permissions.py
+++ b/tahoe_auth0/tests/test_permissions.py
@@ -1,0 +1,44 @@
+"""
+Tests for the permission module.
+"""
+
+from tahoe_auth0.permissions import (
+    get_role_with_default,
+    is_organization_admin,
+    is_organization_staff,
+)
+
+
+def test_organization_admin():
+    """
+    Tests for the is_organization_admin helper.
+    """
+    assert is_organization_admin('Admin'), 'Admin, is admin!'
+    assert not is_organization_admin('Staff'), 'Staff is not an admin'
+    assert not is_organization_admin('Learner'), 'Learner is not an admin'
+    assert not is_organization_admin('SomethingElse'), 'Helper should be safe to use for new roles'
+
+
+def test_organization_staff():
+    """
+    Tests for the is_organization_staff helper.
+    """
+    assert is_organization_staff('Admin'), 'Admin, is also Staff'
+    assert is_organization_staff('Staff'), 'Staff, is Staff'
+    assert not is_organization_staff('Learner'), 'Learner is not an staff'
+    assert not is_organization_staff('SomethingElse'), 'Helper should be safe to use for new roles'
+
+
+def test_get_role_with_default():
+    """
+    Tests for the `get_role_with_default` helper.
+    """
+    assert get_role_with_default(app_metadata={}) == 'Learner', 'Default to learner'
+
+    assert get_role_with_default(app_metadata={
+        'role': 'Admin',
+    }) == 'Admin', 'Should read the provided `Admin` role correctly'
+
+    assert get_role_with_default(app_metadata={
+        'role': 'Learner',
+    }) == 'Learner', 'Should read the provided `Learner` role correctly'

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     ddt
 
 commands=
-  pytest
+  pytest {posargs:}
 
 [testenv:bandit]
 deps =


### PR DESCRIPTION
Now supporting the following roles:

 - `Learner` (default): Gets access to LMS, without additional permissions
 - `Admin`: Gets access to Studio, Dashboard and may get an API token
 - `Staff`: Gets access to Studio

### Roles in Auth0 and Platform 2.0

 - We still need a more definitive guide to Role Based Access Control in Platform 2.0, but Matej provided a basic guide in the [linked comment](https://appsembler.atlassian.net/browse/RED-2738?focusedCommentId=41827):

> Essentially, let’s say Dashboard has 4 levels:
> 
> - Learner
> - Analyst
> - Staff
> - Administrator
> 
> First two upon login to LMS don’t get Studio Staff role in edx
> 
> Second two do
> 
> That way we keep granular access in Dashboard, regardless of current limitations on edx side
> 
> 
> Point of it (Analyst role) is we often have customers who want to give access to data (Figures) to some people, but don’t want them to be able to access Studio, pages administration etc

### Refactoring

 - use `get_auth0_domain()` to avoid initializing Auth0ApiClient() is slow
 - tox: allow running a single test e.g. `tox -e py35-django22 -- tahoe_auth0/tests/test_backend.py::Auth0Test::test_partial_pipeline`
 - bump max line length to 120