### PR TITLE
chore: run bandit via tox and prep for koa

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,35 +1,40 @@
 name: CI
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   test:
-    name: Python ${{ matrix.python-version }} - Django ${{ matrix.django-version }}
+    name: ${{ matrix.name }} ${{ matrix.tox-env }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - python-version: 3.5
-            django-version: 2.2
+          - name: bandit
+            python-version: 3.5
+            tox-env: py3-bandit
+          - name: flake8
+            python-version: 3.5
+            tox-env: py3-flake8
+          - name: Juniper
+            python-version: 3.5
+            tox-env: py35-django22
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-          django-version: ${{ matrix.django-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox flake8 tox semantic-version pre-commit pyjwkest
-      - name: Display Python version
+          pip install tox semantic-version pre-commit
+      - name: Display Python version for ${{ matrix.name }}
         run: python -c "import sys; print(sys.version)"
       - name: Test library version
         run: python -c "from tahoe_auth0 import __version__; from semantic_version import Version; Version(__version__)"
-      - name: Lint with flake8
-        run: flake8 tahoe_auth0 --statistics
       - name: Test with tox
         run: |
-          runenv=$(echo "${{ matrix.python-version }}" | sed 's/\([2-3]\)\.\([0-9]\)/py\1\2/')
-          djangoenv=$(echo "${{ matrix.django-version }}" | sed 's/\([2-3]\)\.\([0-9]\)/django\1\2/')
-          tox -e $runenv-$djangoenv
+          tox -e ${{ matrix.tox-env }}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,9 @@
 [tox]
-envlist = py{35,38,39}-django{22,31,32},bandit
+envlist = py{35,38,39}-django{22,31,32},py3-{bandit,flake8}
 skipsdist = True
+
+[flake8]
+max-line-length = 120
 
 [testenv]
 deps =
@@ -14,8 +17,14 @@ deps =
 commands=
   pytest {posargs:}
 
-[testenv:bandit]
+[testenv:py3-flake8]
+deps =
+    flake8
+commands =
+    flake8 tahoe_auth0 --statistics
+
+[testenv:py3-bandit]
 deps =
     bandit==1.7.1
 commands =
-    bandit -c bandit.yaml -r openedx tahoe_auth0 config
+    bandit -c bandit.yaml -r tahoe_auth0 setup.py


### PR DESCRIPTION
 - refactored and simplified github's tests.yml
 - run on `main` pushed and all pull requests
 - require python3 for flake8 and bandit
