### PR TITLE
use auth0 configs from `admin` via `site-configuration-client`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 # If any of these libraries are not up-to-date, that's fine.
 # We're sticking to our open edX packages versions.
 
+# Open edX requirements: all releases
+site-configuration-client==0.1.4
+
 # Open edX requirements: Juniper
 social-auth-app-django==3.3.0 ; python_version <= "3.5"
 python-jose==3.2.0 ; python_version <= "3.5"

--- a/tahoe_auth0/helpers.py
+++ b/tahoe_auth0/helpers.py
@@ -4,7 +4,8 @@ import urllib.parse
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
-from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+
+from site_config_client.openedx import api as config_client_api
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,7 @@ def is_auth0_enabled():
     Raises `ImproperlyConfigured` if the configuration not correct.
     """
 
-    is_flag_enabled = configuration_helpers.get_value("ENABLE_TAHOE_AUTH0")
+    is_flag_enabled = config_client_api.get_admin_value("ENABLE_TAHOE_AUTH0")
 
     if is_flag_enabled is None:
         is_flag_enabled = settings.FEATURES.get("ENABLE_TAHOE_AUTH0", False)

--- a/tahoe_auth0/tests/conftest.py
+++ b/tahoe_auth0/tests/conftest.py
@@ -1,0 +1,25 @@
+"""
+Pytest helpers.
+"""
+
+import pytest
+
+import tahoe_auth0.helpers
+
+
+@pytest.fixture(scope='function')
+def mock_auth0_settings(monkeypatch, settings):
+    """
+    Mock configs to enable auth0 and set TAHOE_AUTH0_CONFIGS.
+    """
+    def mock_is_auth0_enabled():
+        """Mock for `is_auth0_enabled` to return always True."""
+        return True
+
+    settings.TAHOE_AUTH0_CONFIGS = {
+        'DOMAIN': 'domain.world',
+        'API_CLIENT_ID': 'dummy-client-id',
+        'API_CLIENT_SECRET': 'dummy-client-secret',
+    }
+
+    monkeypatch.setattr(tahoe_auth0.helpers, 'is_auth0_enabled', mock_is_auth0_enabled)

--- a/tahoe_auth0/tests/test_client.py
+++ b/tahoe_auth0/tests/test_client.py
@@ -1,13 +1,13 @@
+import pytest
 from unittest.mock import PropertyMock, patch, Mock
 
 from django.test import TestCase
-from django.conf import settings
 
 from tahoe_auth0.api_client import Auth0ApiClient
 
 
 @patch.object(Auth0ApiClient, "_get_access_token", Mock(return_value='xyz-token'))
-@patch.dict(settings.TAHOE_AUTH0_CONFIGS, DOMAIN='domain.world')
+@pytest.mark.usefixtures('mock_auth0_settings')
 class TestAuth0ApiClient(TestCase):
     def test_init(self):
         client = Auth0ApiClient()


### PR DESCRIPTION
 - refactored many test mocks
 - now `site-configuration-client` is a requirement
